### PR TITLE
centered landing page and fixed redirect for auth

### DIFF
--- a/app/assets/stylesheets/site.css
+++ b/app/assets/stylesheets/site.css
@@ -37,6 +37,10 @@ body {
   border: 2px solid rgb(129,239,188);
 }
 
+a.signup-link{
+  border-top-left-radius: 5px !important;
+  border-bottom-left-radius: 5px !important;
+}
 
 
 #hamburger-menu {
@@ -159,12 +163,15 @@ li .uk-parent:hover {
 }*/
 
 .home-img{
-  margin-left:4.8%;
+  /*margin-left:4.8%;*/
+  /*text-align:center;*/
+  width:100%;
+  position:relative;
 }
 
 #title {
   font-size:150px;
-  margin-top:180px;
+  margin-top:200px;
   margin-bottom:80px;
   text-align:center;
   text-shadow: 2px 2px 3px rgb(44,44,46);
@@ -210,7 +217,13 @@ span.char4 {
 }
 
 #slogan {
-  width:80%;
+  width:70%;
+  position:absolute;
+  left:50%;
+  margin-left:-35%;
+  text-align:center;
+
+
 }
 
 

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -2,7 +2,8 @@ class AuthController < ApplicationController
 
     def failure
       flash[:danger] = "FACEBOOK LOGIN ERROR. Please try again!"
-      redirect_to login_path
+      # redirect_to login_path
+      redirect_to root_path
     end
 
     def callback
@@ -30,7 +31,8 @@ class AuthController < ApplicationController
           redirect_to root_path
         else
           flash[:danger] = "Error. Invalid information inputed."
-          redirect_to new_user_path
+          # redirect_to new_user_path
+          redirect_to root_path
         end
 
       else

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,11 +16,12 @@ class SessionsController < ApplicationController
     elsif @user
       session[:user_id]= @user.id
       flash[:success] ="You have been logged in!"
-      # redirect_to root_path
-      render json: {result:true}
+      redirect_to root_path
+      # render json: {result:true}
     else
-      # flash[:danger] = "Invalid credentials. Please try to login again!"
+      flash[:danger] = "Invalid credentials. Please try to login again!"
       # redirect_to login_path
+      redirect_to root_path
       render json: {result:false,msg:"Invalid credentials. Please try to login again!"}
     end
 

--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -1,14 +1,14 @@
 <%# javascript_include_tag 'textillate' %>
 
-<div class="uk-grid">
-    <div class="home-img uk-container uk-container-center uk-width-small">
-      <div class="uk-container-center" id="title">FSTVL</div>
-      <div class="uk-container uk-container-center uk-width-large-1-1" id ="slogan">
+<!-- <div class="uk-grid"> -->
+    <div class="home-img">
+      <div class="" id="title">FSTVL</div>
+      <div class="" id ="slogan">
            <div id="your-personal">
               YOUR PERSONAL
            </div>
 
-           <div id="conference" class="uk-container-center">
+           <div id="conference" class="">
               CONFERENCE | FESTIVAL | CONVENTION
            </div>
 
@@ -29,4 +29,4 @@
         </div>
       </div>
     </div>
-</div>
+<!-- </div> -->


### PR DESCRIPTION
Hey Timon --

I made a mistake and did this on master instead of a branch, but I didn't do anything too crazy so I thought maybe it might be okay. Let me know if you want me to do a git reset and see if I can get it on a branch if you feel like we have to do that for some reason. 

I couldn't test the flow of the redirects from oauth since it is through your key and I don't have permissions, but I just switched all the redirects that I saw that were going to new_user_path or login_path to root_path since I think those paths are currently going to the older views that are unstyled and not on modals. From what I could tell, success or failure from FB login was also still sending a json instead of redirecting to home, so I switched those also -- but again, I am not sure about those since I wasn't able to test it and I can't remember whether we had it rendering json for an actual reason.

In case I changed something incorrectly, I didn't actually delete any code, I just commented out the old redirects so you can switch them back if you think that they are wrong.

Again, I apologize for forgetting to branch -- it's been a little while! 

Thanks!
